### PR TITLE
Fix copyright notice

### DIFF
--- a/client/src/test/dot_files/simple_task_test.dot
+++ b/client/src/test/dot_files/simple_task_test.dot
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: The PFDL Contributors
+SPDX-FileCopyrightText: The PFDL VS Code Extension Contributors
 SPDX-License-Identifier: MIT
 */
 

--- a/example_programs/1_simple_task_pfdl_and_visu.png.license
+++ b/example_programs/1_simple_task_pfdl_and_visu.png.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: The PFDL Contributors
+SPDX-FileCopyrightText: The PFDL VS Code Extension Contributors
 SPDX-License-Identifier: MIT

--- a/example_programs/2_intermediate_task_pfdl_and_visu.png.license
+++ b/example_programs/2_intermediate_task_pfdl_and_visu.png.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: The PFDL Contributors
+SPDX-FileCopyrightText: The PFDL VS Code Extension Contributors
 SPDX-License-Identifier: MIT

--- a/example_programs/3_complex_task_pfdl_and_visu.png.license
+++ b/example_programs/3_complex_task_pfdl_and_visu.png.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: The PFDL Contributors
+SPDX-FileCopyrightText: The PFDL VS Code Extension Contributors
 SPDX-License-Identifier: MIT


### PR DESCRIPTION
This should probably be `PFDL VS Code Extension Contributors` as these are only a subgroup of the `PDFL Contributors`. The former is used for nearly all other files, expect for PFDL code samples.